### PR TITLE
Allow use package with pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ Tray.create(function(tray) {
 
 # API
 
-## (Promise <Tray>) tray.create({icon, title, action} [, readyCb])
+## (Promise <Tray>) tray.create({icon, title, action, useTempDir} [, readyCb])
 Create a new Tray instance, return a promise / emit a callback when the trayicon is ready.
 If defined, `action` callback is triggered when double clicking the tray.
+Set `useTempDir` to `true` or `"clean"` to copy executable files to temporary directory (`clean` removes temp files on `tray.kill()`). Allows using the package with [pkg](https://www.npmjs.com/package/pkg).
 
 ## (void) tray.setTitle(tray title)
 Set the systray title.

--- a/utils.js
+++ b/utils.js
@@ -53,6 +53,10 @@ function uuid() {
   return crypto.randomBytes(16).toString("hex");
 }
 
+function md5(str) {
+  return crypto.createHash("md5").update(str).digest("hex");
+}
 
 
-module.exports = {escapeXML, attrs, defer, uuid};
+
+module.exports = {escapeXML, attrs, defer, uuid, md5};


### PR DESCRIPTION
Add a `useTempDir` constructor option to copy the executable to temporary directory. Should be used with [pkg](https://www.npmjs.com/package/pkg) as it doesn't allow spawning bundled executables.